### PR TITLE
Add admin restriction middleware

### DIFF
--- a/internal/server/http/auth_middlware.go
+++ b/internal/server/http/auth_middlware.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -54,6 +55,18 @@ func (s *QuoteServer) requireQuizPassed(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		} else {
 			http.Redirect(w, r, s.paths.Quiz, http.StatusFound)
+		}
+	})
+}
+
+// requireAdmin requires that the user be an admin, otherwise a 401 error is returned.
+func (s *QuoteServer) requireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u := ctxval.UserFromContext(r.Context())
+		if u.Admin {
+			next.ServeHTTP(w, r)
+		} else {
+			s.clientError(w, r, errors.New("you are not authorized to access this page"), http.StatusUnauthorized)
 		}
 	})
 }

--- a/internal/server/http/routes.go
+++ b/internal/server/http/routes.go
@@ -12,7 +12,8 @@ func (s *QuoteServer) routes(pubFS fs.FS) {
 	s.mux.Handle(s.paths.Home, http.HandlerFunc(s.homeHandler))
 	s.mux.Handle(s.paths.Quotes, s.requireQuizPassed(http.HandlerFunc(s.quotesHandler)))
 	s.mux.Handle(s.paths.Quiz, s.requireLoggedIn(http.HandlerFunc(s.quizHandler)))
-	s.mux.Handle(s.paths.Admin, s.requireLoggedIn(http.HandlerFunc(s.adminMainHandler)))
+
+	s.mux.Handle(s.paths.Admin, s.requireLoggedIn(s.requireAdmin(http.HandlerFunc(s.adminMainHandler))))
 
 	// TODO: factor out into registerOIDCService(service.OIDC) method to prepare
 	// for multiple OIDC providers


### PR DESCRIPTION
This PR adds a `requireAdmin()` middleware which returns a 401 Unauthorized error when non-admins attempt to access admin routes. Previously, this was only enforced at the service level, which caused a more dramatic 500 error on such unauthorized actions.