### PR TITLE
Add DevMode configuration parameter

### DIFF
--- a/config-ex.yml
+++ b/config-ex.yml
@@ -9,6 +9,7 @@ description: A place to record quotes.
 repo: inmemory
 
 trustProxy: false
+devMode: false
 
 OIDCProvider:
   name: google

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,7 +6,7 @@ On Windows, the default configuration file location is `.\config.yml`, while on 
 
 ## Configuration 'Merging'
 
-Many configuration parameters can be set from multiple sources. The following list outlines the order in which configuration parameters are merged. If a parameter is specified by multiple sources, the value from the last source (highest number) will be used.
+Many configuration parameters can be set from multiple sources. The following list outlines the order in which configuration parameters are merged. If a parameter is specified by multiple sources, the value from the last source (highest number) will be used. The exception is boolean parameters (such as DevMode and TrustProxy), which are merged by logical OR, and therefore a value of false will not overwrite a prior true.
 
 1. Default values
 2. Configuration file
@@ -26,6 +26,7 @@ The following table outlines parameters which can be configured, as well as thei
 | **Repo** dictates what type of storage the application should use for data persistence. (either 'inmemory' or 'sqlite')                                                         | `repo`        | `EP_REPO`            | inmemory                                                                                                                         |
 | **DBLoc** is the location where the database can be found. In the case of an SQLite repository, this is the path to database file. It has no effect on an in-memory repository. | `DBLoc`       | `EP_DBLOC`           | Unix: `/var/epigram/epigram.db`, Windows: `.\epigram.db`                                                                         |
 | **TrustProxy** dictates whether `X-Forwarded-For` header should be trusted to obtain the client IP, or if the requestor IP should be used instead.                              | `trustProxy`  | `EP_TRUSTPROXY`      | false                                                                                                                            |
+| **DevMode** dictates whether the application should run in development mode, which disables asset embedding and caching for easier frontend development.                        | `devMode`     | `EP_DEVMODE`         | false                                                                                                                            |
 
 ### OIDC Provider Configuration
 
@@ -62,6 +63,7 @@ repo: SQLite
 DBLoc: ./epigram.db
 
 trustProxy: false
+devMode: false
 
 OIDCProvider:
   name: google

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,11 +67,14 @@ type Application struct {
 	OIDCProvider OIDCProvider `yaml:"OIDCProvider"`
 	// EntryQuestions is an array of questions.
 	EntryQuestions []EntryQuestion `yaml:"entryQuestions"`
+	// DevMode dictates whether the application should run in development mode, which disables asset embedding and caching for easier frontend development.
+	DevMode bool `yaml:"devMode"`
 }
 
 // merge applies all non-nil / non-default values from the provided layer to the base layer, and returns the result.
 //
-// Because TrustProxy is a bool, and it's default value is false, a false TrustProxy will not overwrite a base true.
+// Boolean values (like DevMode and TrustProxy) are merged by ORing the two values together, and as such, a false value
+// in the layer will not override a true value in the base.
 func (base Application) merge(layer Application) Application {
 	if layer.Address != "" {
 		base.Address = layer.Address
@@ -102,6 +105,9 @@ func (base Application) merge(layer Application) Application {
 	}
 	if len(layer.EntryQuestions) > 0 {
 		base.EntryQuestions = layer.EntryQuestions
+	}
+	if layer.DevMode {
+		base.DevMode = layer.DevMode
 	}
 	return base
 }

--- a/internal/config/environment.go
+++ b/internal/config/environment.go
@@ -35,6 +35,7 @@ func fromEnvironment() Application {
 	port := uint16(p64)
 
 	trustProxy, _ := strconv.ParseBool(getEnvVar("TrustProxy"))
+	devMode, _ := strconv.ParseBool(getEnvVar("DevMode"))
 
 	return Application{
 		Title:       getEnvVar("Title"),
@@ -45,5 +46,6 @@ func fromEnvironment() Application {
 		Repo:        repoFromString(getEnvVar("Repo")),
 		DBLoc:       getEnvVar("DBLoc"),
 		TrustProxy:  trustProxy,
+		DevMode:     devMode,
 	}
 }

--- a/internal/config/yaml.go
+++ b/internal/config/yaml.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,7 +19,7 @@ func (repo *Repository) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
-// parseYAML accepts an array of bytes, and parses it into an Applicaiton configuration
+// parseYAML accepts an array of bytes, and parses it into an Application configuration
 func parseYAML(in []byte) (Application, error) {
 	var cfg Application
 

--- a/internal/server/http/frontend/embedfs.go
+++ b/internal/server/http/frontend/embedfs.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"os"
 )
 
 //go:embed public
@@ -13,19 +14,35 @@ var publicEmbedFS embed.FS
 var templateEmbedFS embed.FS
 
 // templateFS returns the filesystem containing template files, rooted inside the templates subdirectory
-func templateFS() (fs.FS, error) {
-	filesys, err := fs.Sub(templateEmbedFS, "templates")
-	if err != nil {
-		return nil, fmt.Errorf("creating embedFS: %v", err)
+func (e TemplateEngine) templateFS() (fs.FS, error) {
+	var fsys fs.FS
+	var err error
+	if e.DevMode {
+		fsys = os.DirFS("internal/server/http/frontend/templates")
+	} else {
+		fsys = templateEmbedFS
+		fsys, err = fs.Sub(fsys, "templates")
 	}
-	return filesys, nil
+
+	if err != nil {
+		return nil, fmt.Errorf("creating templateFS: %v", err)
+	}
+	return fsys, nil
 }
 
 // PublicFS returns the filesystem containing public files (css, js, etc), rooted inside the public subdirectory
-func PublicFS() (fs.FS, error) {
-	filesys, err := fs.Sub(publicEmbedFS, "public")
+func (e TemplateEngine) PublicFS() (fs.FS, error) {
+	var fsys fs.FS
+	var err error
+	if e.DevMode {
+		fsys = os.DirFS("internal/server/http/frontend/public")
+	} else {
+		fsys = publicEmbedFS
+		fsys, err = fs.Sub(fsys, "public")
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("creating publicFS: %v", err)
 	}
-	return filesys, nil
+	return fsys, nil
 }

--- a/internal/server/http/frontend/templating.go
+++ b/internal/server/http/frontend/templating.go
@@ -13,6 +13,9 @@ import (
 type TemplateEngine struct {
 	views  map[string]*template.Template
 	rootTD RootTD
+	// If devMode is true, the TemplateEngine will use local files instead of the embedded filesystems,
+	// and will reload the templates on every render.
+	DevMode bool
 }
 
 // NewTemplateEngine creates a new template engine, and initializes it's views so that it is ready
@@ -22,22 +25,25 @@ func NewTemplateEngine(rootTD RootTD) (TemplateEngine, error) {
 		rootTD: rootTD,
 	}
 
-	tmplFS, err := templateFS()
+	err := e.initViews()
 	if err != nil {
 		return TemplateEngine{}, err
 	}
-
-	e.initViews(tmplFS)
 
 	return e, nil
 }
 
 // initViews initializes a cache of view templates from the provided filesystem in the form of a
 // map relating page view names to complete templates, with components and layouts included.
-func (e *TemplateEngine) initViews(fileSys fs.FS) error {
+func (e *TemplateEngine) initViews() error {
+	tmplFS, err := e.templateFS()
+	if err != nil {
+		return err
+	}
+
 	e.views = make(map[string]*template.Template)
 
-	views, err := fs.Glob(fileSys, "views/*.gohtml")
+	views, err := fs.Glob(tmplFS, "views/*.gohtml")
 	if err != nil {
 		return err
 	}
@@ -45,13 +51,13 @@ func (e *TemplateEngine) initViews(fileSys fs.FS) error {
 	for _, view := range views {
 		name := filepath.Base(view)
 		// Parse the view with functions
-		t, err := template.New(name).Funcs(templateFuncs).ParseFS(fileSys, view)
+		t, err := template.New(name).Funcs(templateFuncs).ParseFS(tmplFS, view)
 		if err != nil {
 			return err
 		}
 
 		// Parse associated components and layouts
-		t, err = t.ParseFS(fileSys, "components/*.gohtml", "base.gohtml")
+		t, err = t.ParseFS(tmplFS, "components/*.gohtml", "base.gohtml")
 		if err != nil {
 			return err
 		}
@@ -64,7 +70,16 @@ func (e *TemplateEngine) initViews(fileSys fs.FS) error {
 }
 
 // RenderPage renders the specified view with the provided data joined to the RootTD.
-func (e *TemplateEngine) RenderPage(w io.Writer, page Page) error {
+func (e TemplateEngine) RenderPage(w io.Writer, page Page) error {
+
+	// If devMode is true, reload the templates on every render
+	if e.DevMode {
+		err := e.initViews()
+		if err != nil {
+			return err
+		}
+	}
+
 	t, ok := e.views[page.viewName()]
 	if !ok {
 		return errors.New("template not found in views")

--- a/internal/server/http/server.go
+++ b/internal/server/http/server.go
@@ -48,14 +48,6 @@ func (s *QuoteServer) Init() error {
 		return err
 	}
 
-	// Initialize http mux and routes
-	s.mux = http.NewServeMux()
-	pubFS, err := frontend.PublicFS()
-	if err != nil {
-		return err
-	}
-	s.routes(pubFS)
-
 	// Initialize template engine
 	tmpl, err := frontend.NewTemplateEngine(frontend.RootTD{
 		Title:       s.Config.Title,
@@ -65,7 +57,20 @@ func (s *QuoteServer) Init() error {
 	if err != nil {
 		return err
 	}
+	if s.Config.DevMode {
+		s.Logger.Warn("Running in development mode. Template engine performance reduced.")
+		tmpl.DevMode = true
+	}
 	s.tmpl = tmpl
+
+	// Initialize http mux and routes
+	s.mux = http.NewServeMux()
+	pubFS, err := tmpl.PublicFS()
+	if err != nil {
+		return err
+	}
+	s.routes(pubFS)
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds a DevMode configuration parameter which forces reading frontend assets from disk instead of embedded file systems. This means changes to templates or static frontend assets take effect immediately without requiring the application to be restarted.