### PR TITLE
Fix redirects to use 303 "See Other" instead of 302 "Found"

### DIFF
--- a/internal/server/http/auth_middlware.go
+++ b/internal/server/http/auth_middlware.go
@@ -41,7 +41,7 @@ func (s *QuoteServer) requireLoggedIn(next http.Handler) http.Handler {
 		if u.ID != "" {
 			next.ServeHTTP(w, r)
 		} else {
-			http.Redirect(w, r, s.paths.Login, http.StatusFound)
+			http.Redirect(w, r, s.paths.Login, http.StatusSeeOther)
 		}
 	})
 }
@@ -54,7 +54,7 @@ func (s *QuoteServer) requireQuizPassed(next http.Handler) http.Handler {
 		if u.QuizPassed {
 			next.ServeHTTP(w, r)
 		} else {
-			http.Redirect(w, r, s.paths.Quiz, http.StatusFound)
+			http.Redirect(w, r, s.paths.Quiz, http.StatusSeeOther)
 		}
 	})
 }

--- a/internal/server/http/oidc_handler.go
+++ b/internal/server/http/oidc_handler.go
@@ -43,7 +43,7 @@ func (s *QuoteServer) oidcLoginHandler(oidc service.OIDC) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// first, check if user is already signed in. If so, redirect to the quotes page.
 		if ctxval.UserFromContext(r.Context()).ID != "" {
-			http.Redirect(w, r, s.paths.Quotes, http.StatusFound)
+			http.Redirect(w, r, s.paths.Quotes, http.StatusSeeOther)
 			return
 		}
 
@@ -60,7 +60,7 @@ func (s *QuoteServer) oidcLoginHandler(oidc service.OIDC) http.Handler {
 		setCallbackCookie(w, r, "state", state)
 		setCallbackCookie(w, r, "nonce", nonce)
 
-		http.Redirect(w, r, oidc.RedirectURL(state, nonce), http.StatusFound)
+		http.Redirect(w, r, oidc.RedirectURL(state, nonce), http.StatusSeeOther)
 	})
 }
 
@@ -97,6 +97,6 @@ func (s *QuoteServer) oidcCallbackHandler(oidc service.OIDC) http.Handler {
 			// Session expires on client one hour before server to account for sync differences.
 			Expires: sess.Expires.Add(-time.Hour),
 		})
-		http.Redirect(w, r, s.paths.Quotes, http.StatusFound)
+		http.Redirect(w, r, s.paths.Quotes, http.StatusSeeOther)
 	})
 }

--- a/internal/server/http/quiz_handler.go
+++ b/internal/server/http/quiz_handler.go
@@ -50,7 +50,7 @@ func (s *QuoteServer) quizHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if u.QuizPassed {
-			http.Redirect(w, r, s.paths.Quotes, http.StatusFound)
+			http.Redirect(w, r, s.paths.Quotes, http.StatusSeeOther)
 			return
 		}
 

--- a/internal/server/http/quotes_handler.go
+++ b/internal/server/http/quotes_handler.go
@@ -81,7 +81,7 @@ func (s *QuoteServer) quotesHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		http.Redirect(w, r, s.paths.Quotes, http.StatusFound)
+		http.Redirect(w, r, s.paths.Quotes, http.StatusSeeOther)
 	default:
 		s.methodNotAllowedError(w, r)
 		return


### PR DESCRIPTION
When redirecting users through the application, and after form submissions, an [HTTP 303 "See Other"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303) is more appropriate than the previously used [HTTP 302 "Found"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302).