### PR TITLE
Improve logger functionality with NO_COLOR and stderr support

### DIFF
--- a/cmd/legacy/main.go
+++ b/cmd/legacy/main.go
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	// Initialize logger
-	log := logger.New(os.Stdout, false)
+	log := logger.New(os.Stdout, os.Stderr, false)
 	log.Level = logger.LevelDebug
 
 	// Declare and parse flags

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -20,7 +20,7 @@ import (
 
 func main() {
 	// Initialize logger
-	log := logger.New(os.Stdout, true)
+	log := logger.New(os.Stdout, os.Stderr, true)
 	log.Level = logger.LevelDebug
 
 	// Configuration parsing

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,6 +27,7 @@ The following table outlines parameters which can be configured, as well as thei
 | **DBLoc** is the location where the database can be found. In the case of an SQLite repository, this is the path to database file. It has no effect on an in-memory repository. | `DBLoc`       | `EP_DBLOC`           | Unix: `/var/epigram/epigram.db`, Windows: `.\epigram.db`                                                                         |
 | **TrustProxy** dictates whether `X-Forwarded-For` header should be trusted to obtain the client IP, or if the requestor IP should be used instead.                              | `trustProxy`  | `EP_TRUSTPROXY`      | false                                                                                                                            |
 | **DevMode** dictates whether the application should run in development mode, which disables asset embedding and caching for easier frontend development.                        | `devMode`     | `EP_DEVMODE`         | false                                                                                                                            |
+| **NoColor** disables colored logging output when set to any value (see [no-color.org](https://no-color.org)).                                                                   |               | `NO_COLOR`           |                                                                                                                                  |
 
 ### OIDC Provider Configuration
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -47,11 +47,23 @@ type Logger struct {
 
 // New returns a new Logger that writes to the provided io.Writer. If timestamp is true, the logger will prefix each
 // message with a timestamp.
-func New(out io.Writer, timestamp bool) Logger {
+//
+// If the NO_COLOR environment variable is set, the logger will not use ANSI color escape codes.
 	var flags int
 	if timestamp {
 		flags = log.Ldate | log.Ltime
 	}
+
+	if os.Getenv("NO_COLOR") != "" {
+		return Logger{
+			debugLog: log.New(out, "DEBUG \t", flags),
+			infoLog:  log.New(out, "INFO \t", flags),
+			warnLog:  log.New(out, "WARN \t", flags),
+			fatalLog: log.New(out, "FATAL \t", flags),
+		}
+
+	}
+
 	return Logger{
 		debugLog: log.New(out, colorCyan+"DEBUG \t"+colorReset, flags),
 		infoLog:  log.New(out, colorBlue+"INFO \t"+colorReset, flags),

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -48,7 +48,9 @@ type Logger struct {
 // New returns a new Logger that writes to the provided io.Writer. If timestamp is true, the logger will prefix each
 // message with a timestamp.
 //
+// Debug and Info messages are written to out, while Warn and Fatal messages are written to outErr.
 // If the NO_COLOR environment variable is set, the logger will not use ANSI color escape codes.
+func New(out, outErr io.Writer, timestamp bool) Logger {
 	var flags int
 	if timestamp {
 		flags = log.Ldate | log.Ltime
@@ -58,8 +60,8 @@ type Logger struct {
 		return Logger{
 			debugLog: log.New(out, "DEBUG \t", flags),
 			infoLog:  log.New(out, "INFO \t", flags),
-			warnLog:  log.New(out, "WARN \t", flags),
-			fatalLog: log.New(out, "FATAL \t", flags),
+			warnLog:  log.New(outErr, "WARN \t", flags),
+			fatalLog: log.New(outErr, "FATAL \t", flags),
 		}
 
 	}
@@ -67,8 +69,8 @@ type Logger struct {
 	return Logger{
 		debugLog: log.New(out, colorCyan+"DEBUG \t"+colorReset, flags),
 		infoLog:  log.New(out, colorBlue+"INFO \t"+colorReset, flags),
-		warnLog:  log.New(out, colorYellow+"WARN \t"+colorReset, flags),
-		fatalLog: log.New(out, colorRed+"FATAL \t"+colorReset, flags),
+		warnLog:  log.New(outErr, colorYellow+"WARN \t"+colorReset, flags),
+		fatalLog: log.New(outErr, colorRed+"FATAL \t"+colorReset, flags),
 	}
 }
 


### PR DESCRIPTION
This PR adds additional functionality to the epigram logging package. It now observes the `NO_COLOR` environment variable per the rules at [no-color.org](https://no-color.org), and supports writing info and error messages to different destinations (e.g. stdout and stderr).